### PR TITLE
Add Claude Code automations, hooks, and project guardrails

### DIFF
--- a/.claude/agents/resume-content-reviewer.md
+++ b/.claude/agents/resume-content-reviewer.md
@@ -1,0 +1,13 @@
+---
+name: resume-content-reviewer
+description: After any edit to data/resume.ts, validate that all required profile fields are present, all referenced image paths exist under assets/images/, and all URLs are well-formed.
+---
+
+Read `data/resume.ts` and list the files in `assets/images/`. Check:
+
+1. Profile has `name`, `jobTitle`, `summary`, and `linkedinUrl` set and non-empty
+2. Every image path referenced in the data resolves to an existing file under `assets/images/`
+3. All URLs are well-formed (start with `https://` or `mailto:`)
+4. No placeholder text remains (e.g. "Lorem ipsum", "TODO", "FIXME", "placeholder")
+
+Report issues as a concise bullet list. If everything looks good, say so in one line.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null); if echo \"$file\" | grep -q 'yarn\\.lock'; then echo 'ERROR: Do not edit yarn.lock directly. Run: docker compose run --rm app yarn install'; exit 2; fi"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null); if echo \"$file\" | grep -qE '\\.(vue|ts)$' && ! echo \"$file\" | grep -q 'tests/'; then docker compose run --rm app yarn typecheck 2>&1 | tail -10; fi"
+          },
+          {
+            "type": "command",
+            "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null); if echo \"$file\" | grep -q 'tests/unit/'; then docker compose run --rm app yarn test:unit 2>&1 | tail -15; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/make-task/SKILL.md
+++ b/.claude/skills/make-task/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: make-task
+description: Run any Makefile target via docker compose and report the result. Usage: /make-task <target>
+disable-model-invocation: true
+---
+
+Run `make {{ args }}` and report the full output, highlighting any errors or warnings. If the target fails, show the last 30 lines of output and the exit code.

--- a/.claude/skills/merge-dep-prs/SKILL.md
+++ b/.claude/skills/merge-dep-prs/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: merge-dep-prs
+description: Batch-merge multiple open dependency PRs into a single branch, resolve conflicts, and regenerate yarn.lock. Usage: /merge-dep-prs
+disable-model-invocation: true
+---
+
+Merge all open dependency PRs into a single branch:
+
+1. List open PRs with `gh pr list --state open`
+2. Create a new branch: `git checkout -b chore/merge-deps-$(date +%Y%m%d) main`
+3. Merge in order — workflow-file-only PRs first, then PRs touching `package.json`, then `yarn.lock`-only PRs
+4. For `package.json` conflicts: keep ALL version bumps from every branch (do not revert any)
+5. For `yarn.lock` conflicts: run `git checkout --theirs yarn.lock` then `docker compose run --rm app yarn install` to regenerate
+6. Verify with `make typecheck && make test-unit`
+7. Report what was merged and any issues found

--- a/.claude/skills/update-resume/SKILL.md
+++ b/.claude/skills/update-resume/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: update-resume
+description: Guided update of resume content in data/resume.ts. Usage: /update-resume <what to change>
+---
+
+Read `data/resume.ts` to understand the current content and TypeScript schema. Apply the requested change ({{ args }}), preserving all existing types and structure. After editing, invoke the `resume-content-reviewer` agent to validate the result.

--- a/.claude/skills/verify-build/SKILL.md
+++ b/.claude/skills/verify-build/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: verify-build
+description: Run the full pre-PR validation pipeline — typecheck, unit tests, then static build with link checker. Reports pass/fail per step.
+disable-model-invocation: true
+---
+
+Run each step sequentially. Stop and report on first failure.
+
+1. `make typecheck` — TypeScript and vue-tsc checks
+2. `make test-unit` — Vitest unit tests
+3. `make build` — full static site generation with link checker (set NUXT_LINK_CHECKER_REMOTE=1 only if remote link checking is needed)
+
+Report: ✓ or ✗ for each step with a one-line summary. On failure show the relevant error output.

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ test-results
 *.log
 .DS_Store
 .remember
+.claude
 .env
 .env.local
 .env.*

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ desktop.ini
 
 # Claude Code
 .remember/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,11 @@ make nginx        # serves .output/public via nginx on port 8030
 - Do not push directly to `main`
 - Keep action pins intact in workflow files
 - Prefer updating docs and tests alongside structural app changes so the repo never documents the old stack
+- When merging multiple dependency PRs, resolve `yarn.lock` conflicts with `git checkout --theirs yarn.lock && docker compose run --rm app yarn install` — never merge it manually
+
+## Claude Code automations
+
+- `/verify-build` — typecheck + unit tests + build in sequence
+- `/merge-dep-prs` — batch-merge dependency PRs, handles yarn.lock regeneration
+- `/update-resume` — guided edits to `data/resume.ts` with post-edit validation
+- `/make-task <target>` — run any Makefile target


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with project-scoped hooks:
  - **PreToolUse**: blocks direct `yarn.lock` edits (must use `yarn install`)
  - **PostToolUse**: runs `typecheck` after `.vue`/`.ts` edits; runs unit tests after `tests/unit/` edits
- Adds four skills invocable via `/skill-name`:
  - `/verify-build` — typecheck + unit tests + build in sequence
  - `/merge-dep-prs` — batch-merge dependency PRs with yarn.lock regeneration
  - `/update-resume` — guided edits to `data/resume.ts` with post-edit validation
  - `/make-task <target>` — run any Makefile target
- Adds `resume-content-reviewer` subagent that validates `data/resume.ts` after edits
- Excludes `.claude/` from Docker build context (`.dockerignore`)
- Gitignores `.claude/settings.local.json` to prevent local secrets (e.g. `GITHUB_TOKEN`) from being committed
- Updates `CLAUDE.md` with yarn.lock conflict resolution pattern and skill shortcuts

## Test plan

- [x] `settings.local.json` absent from staged files (token protected)
- [x] `.claude/` present and committed (hooks/skills are team-shared)
- [x] All existing tests still pass (`make typecheck && make test-unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)