### PR TITLE
Merge dependency updates and document Docker workflow rules

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8 # v1
+        uses: anthropics/claude-code-action@2ff1acb3ee319fa302837dad6e17c2f36c0d98ea # v1
         with:
           allowed_bots: 'renovate,dependabot'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8 # v1
+        uses: anthropics/claude-code-action@2ff1acb3ee319fa302837dad6e17c2f36c0d98ea # v1
         with:
           allowed_bots: 'renovate,dependabot'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ make test
 make ps / logs / stop / down
 ```
 
+Never use `docker exec` to run commands — always use `docker compose run --rm app <cmd>`.
+
 Raw docker compose equivalents also work if needed:
 
 ```bash
@@ -77,6 +79,7 @@ make nginx        # serves .output/public via nginx on port 8030
 - Keep action pins intact in workflow files
 - Prefer updating docs and tests alongside structural app changes so the repo never documents the old stack
 - When merging multiple dependency PRs, resolve `yarn.lock` conflicts with `git checkout --theirs yarn.lock && docker compose run --rm app yarn install` — never merge it manually
+- After any `yarn.lock` change (merge or conflict resolution), run `make install` before running tests — containers don't auto-reflect updated lockfiles
 
 ## Claude Code automations
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev build preview typecheck test-unit test-e2e test nginx ps logs stop down
+.PHONY: help install dev build preview typecheck test-unit test-e2e test git-maintenance nginx ps logs stop down
 
 DOCKER_COMPOSE := docker compose
 APP_SERVICE := app
@@ -14,6 +14,7 @@ help:
 		"  make test-unit   Run Vitest unit tests" \
 		"  make test-e2e    Run Playwright end-to-end tests" \
 		"  make test        Run the full test suite" \
+		"  make git-maintenance Prune remote refs and run git garbage collection" \
 		"  make nginx       Serve .output/public with nginx on port 8030" \
 		"  make ps          Show Docker Compose service status" \
 		"  make logs        Tail Docker Compose logs" \
@@ -43,6 +44,9 @@ test-e2e:
 
 test:
 	$(DOCKER_COMPOSE) run --rm $(APP_SERVICE) yarn test
+
+git-maintenance:
+	git remote prune origin && git gc --prune=1.month.ago --no-quiet
 
 nginx:
 	$(DOCKER_COMPOSE) up nginx

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,207 @@
+# Suggested Improvement Tasks
+
+Each task follows the **INVEST** model: Independent, Negotiable, Valuable, Estimable, Small, Testable.
+
+---
+
+## Performance
+
+### PERF-1 — Replace legacy carousel JS with a native Vue component
+
+**Why:** `TestimonialCarousel.vue` delegates all behavior to Bootstrap carousel loaded via `plugins/legacy-runtime.client.ts`. This pulls in jQuery (~85 KB), Bootstrap JS, Popper, and Tether sequentially on every page load, blocking interactivity by an estimated 200–400 ms.
+
+**Acceptance criteria:**
+- `TestimonialCarousel.vue` auto-advances slides on an 8-second interval using Vue `setInterval` or `useIntervalFn`
+- Previous/next controls work without any legacy scripts
+- No regression in the existing E2E carousel test (`tests/e2e/app.spec.ts`)
+- `public/legacy/scripts/` jQuery, Bootstrap, Popper, and Tether files are no longer loaded
+
+---
+
+### PERF-2 — Lazy-load below-the-fold images
+
+**Why:** `pages/index.vue` renders all `<img>` elements and CSS `background-image` divs immediately. The six images below the hero section (publications, education, testimonial avatars) are not visible on first paint but still download unconditionally, wasting bandwidth on mobile connections.
+
+**Acceptance criteria:**
+- All `<img>` elements below the hero section have `loading="lazy"`
+- No visible change to layout or paint order for images already in the viewport
+- Verified with Chrome DevTools Network throttling (3G) showing deferred requests for off-screen images
+
+---
+
+### PERF-3 — Convert JPG/PNG hero and background images to WebP
+
+**Why:** `assets/images/mbr-1920x1246.jpg` is 288 KB and `background9.jpg` is 60 KB. Both images are format choices made in 2016-era Mobirise and have no modern equivalents in the repo. WebP delivers 25–35% smaller files with equivalent visual quality.
+
+**Acceptance criteria:**
+- Hero and all background images added as WebP variants alongside original fallbacks
+- `nuxt.config.ts` or `pages/index.vue` serves WebP to supporting browsers (via `<picture>` element or Nuxt image provider)
+- Total image transfer weight for the homepage is reduced by ≥ 20% (measured in DevTools)
+- No visual regression on Chrome, Firefox, and Safari
+
+---
+
+### PERF-4 — Remove duplicate image assets from `public/legacy/images/`
+
+**Why:** Image files exist in both `assets/images/` (used by the Nuxt app) and `public/legacy/images/` (orphaned from the Mobirise era). The duplicate copies add dead weight to the Docker image, git history, and deployed bundle.
+
+**Acceptance criteria:**
+- `public/legacy/images/` is removed or confirmed empty
+- All image references in `pages/index.vue` and `data/resume.ts` resolve correctly from `assets/images/`
+- `make build` completes without errors and the homepage renders all images correctly
+- `make preview` visual check shows no broken images
+
+---
+
+## Accessibility
+
+### A11Y-1 — Add descriptive alt text to publication images
+
+**Why:** `pages/index.vue` line 144 sets `alt=""` on publication images, hiding their content from screen readers. Publication images are meaningful — they show book/article covers — and should be described for visually impaired users.
+
+**Acceptance criteria:**
+- Each publication item in `data/resume.ts` has an `imageAlt` field (e.g. `"Cover of Book Title by Author"`)
+- `pages/index.vue` binds `:alt="item.imageAlt"` on the publication `<img>` element
+- `tests/unit/resume-data.test.ts` asserts that every publication entry has a non-empty `imageAlt` string
+- TypeScript interface for publication type updated to require the field
+
+---
+
+### A11Y-2 — Add ARIA labels and live region to the testimonial carousel
+
+**Why:** `TestimonialCarousel.vue` has no `aria-label` on the Previous/Next buttons and no `aria-live` region to announce slide transitions to screen reader users. Carousel controls announce nothing when activated.
+
+**Acceptance criteria:**
+- Previous and Next buttons have explicit `aria-label="Previous testimonial"` and `aria-label="Next testimonial"` attributes
+- An `aria-live="polite"` region containing the active slide content is present in the DOM
+- Slide indicator dots have `aria-current="true"` on the active slide and `aria-label="Slide N of M"` on each
+- Verified with VoiceOver (macOS) or NVDA (Windows) that slide transitions are announced
+
+---
+
+### A11Y-3 — Add axe-core accessibility audit to the Playwright E2E suite
+
+**Why:** `tests/e2e/app.spec.ts` validates functional behavior but runs no accessibility checks. Critical violations (contrast failures, missing labels, invalid ARIA) can silently regress between deploys with no automated catch.
+
+**Acceptance criteria:**
+- `@axe-core/playwright` added to `devDependencies`
+- An accessibility check is run on the homepage and confirmation page in `app.spec.ts` using `checkA11y` or equivalent
+- The test fails if axe reports any `critical` or `serious` violations
+- `make test-e2e` passes cleanly after all existing accessibility issues are resolved first
+
+---
+
+## Testing
+
+### TEST-1 — Add mobile viewport tests to the Playwright suite
+
+**Why:** The E2E tests only run at the default desktop viewport. The site uses Bootstrap's responsive grid (via legacy CSS), but there is no automated verification that the layout, navigation, and carousel function correctly on mobile screen sizes.
+
+**Acceptance criteria:**
+- A second Playwright project (or `test.use({ viewport })` block) exercises the homepage at 375×812 (iPhone 14) and 768×1024 (iPad) viewports
+- Tests assert: hero section is visible, experience section renders without overflow, carousel controls are tappable (44×44 px minimum hit area)
+- No existing tests are broken or skipped
+
+---
+
+### TEST-2 — Extend unit tests to validate required resume data fields
+
+**Why:** `tests/unit/resume-data.test.ts` only checks array lengths and link format. A missing `title`, empty `summary`, or `undefined` date in resume data would silently produce a broken page — there is no guard against incomplete entries.
+
+**Acceptance criteria:**
+- Each `experience` item is asserted to have non-empty `company`, `title`, `startDate`, and `description`
+- Each `talk` item is asserted to have non-empty `title`, `event`, and `href`
+- Each `testimonial` item is asserted to have non-empty `quote`, `author`, and `role`
+- Tests are table-driven (one loop per array) so adding entries to `resume.ts` automatically covers them
+
+---
+
+## Developer Experience
+
+### DX-1 — Add ESLint and Prettier with Vue and TypeScript rules
+
+**Why:** The repo has no linter or formatter. Code style is enforced only through `.editorconfig` (indent/newline rules). Inconsistent whitespace, unused variables, and Vue-specific anti-patterns go uncaught until review.
+
+**Acceptance criteria:**
+- `@nuxt/eslint` (or `eslint-config-vue` + TypeScript plugin) added to `devDependencies`
+- `eslint.config.js` (flat config) created with rules for Vue 3, TypeScript, and the project's 2-space indent
+- `prettier.config.js` created and `eslint-prettier` integration added to avoid conflicts
+- `package.json` gains a `lint` script: `yarn lint` (lint check) and `yarn lint:fix` (auto-fix)
+- CI `node.js.yml` workflow runs `yarn lint` before `yarn test`
+
+---
+
+### DX-2 — Enable TypeScript strict mode and resolve all type errors
+
+**Why:** `tsconfig.json` does not enable `strict: true`, so null-safety, implicit `any`, and unchecked index accesses are not caught. `OgImage/Resume.satori.vue` also has no typed props definition, making it invisible to TypeScript.
+
+**Acceptance criteria:**
+- `tsconfig.json` sets `"strict": true`
+- `OgImage/Resume.satori.vue` uses `defineProps<{ ... }>()` with explicit types for all props it receives
+- `yarn typecheck` passes with zero errors after enabling strict mode
+- No `@ts-ignore` or `as any` casts added as workarounds
+
+---
+
+### DX-3 — Cache Playwright browsers between CI runs
+
+**Why:** `node.js.yml` runs `playwright install` on every CI run, downloading Chromium (~130 MB) each time. This adds 60–90 seconds to every PR check and consumes GitHub Actions cache quota unnecessarily.
+
+**Acceptance criteria:**
+- `actions/cache` step added to `node.js.yml` keyed on the Playwright version from `package.json`
+- Cache hit skips `playwright install --with-deps`
+- Cache miss installs and stores the browsers for the next run
+- CI wall time for the `playwright install` step drops to < 5 seconds on cache hits
+
+---
+
+## Security & Privacy
+
+### SEC-1 — Move personal contact details to environment variables
+
+**Why:** `data/resume.ts` hard-codes phone number and email address as plain strings. These are baked into the built static output and indexed by search engines and scrapers, making them trivially harvestable. Storing them as environment variables keeps them out of git history and allows rotation without a code change.
+
+**Acceptance criteria:**
+- `NUXT_PUBLIC_CONTACT_EMAIL` and `NUXT_PUBLIC_CONTACT_PHONE` added as runtime config keys in `nuxt.config.ts`
+- `data/resume.ts` references `useRuntimeConfig().public.contactEmail` (or equivalent composable pattern) instead of string literals
+- A `.env.example` file documents the required variable names with placeholder values
+- `make build` fails with a clear error if either variable is unset
+- Phone and email are absent from the committed TypeScript source
+
+---
+
+### SEC-2 — Add a Content Security Policy header
+
+**Why:** The site loads third-party fonts and legacy scripts from `public/legacy/` but has no CSP header to restrict unexpected script execution or data exfiltration. A static CSP header is straightforward to add via `_headers` (Cloudflare Pages) or `nuxt.config.ts` `routeRules`.
+
+**Acceptance criteria:**
+- A `Content-Security-Policy` header is set for all routes via `nuxt.config.ts` `routeRules` or a `public/_headers` file
+- Policy allows: `'self'` for scripts and styles, the legacy fonts inline as `font-src`, and no `unsafe-eval`
+- `make preview` response includes the header (verified with `curl -I http://localhost:3000`)
+- No console CSP violation errors appear in the browser on the homepage
+
+---
+
+## SEO & Content
+
+### SEO-1 — Add structured data for Person and ContactPoint schemas
+
+**Why:** `@nuxtjs/seo` generates basic schema.org output, but the site is a personal resume — adding `Person` with `ContactPoint`, `sameAs` (LinkedIn), and `knowsAbout` (skills array) provides richer Google Knowledge Panel eligibility and better search result presentation.
+
+**Acceptance criteria:**
+- `pages/index.vue` uses `useSchemaOrg` (from `nuxtjs/seo`) to emit a `Person` entity with: `name`, `jobTitle`, `url`, `sameAs: [linkedinUrl]`, and `knowsAbout` derived from the skills array in `data/resume.ts`
+- `ContactPoint` with `contactType: "professional"` and `email` is nested inside `Person`
+- `make build` output includes the schema in the generated HTML
+- Schema validates without errors in the Google Rich Results Test
+
+---
+
+### SEO-2 — Rename `.github/dependabot.yml` to `.github/renovate.json`
+
+**Why:** `.github/dependabot.yml` contains a Renovate configuration (`$schema: renovate`), not a Dependabot configuration. The filename is misleading — GitHub reads `dependabot.yml` for Dependabot and ignores it for Renovate. If Renovate is the intended tool, it should be configured in the standard `renovate.json` location. If Dependabot is intended, the file contents should be replaced.
+
+**Acceptance criteria:**
+- The repository has exactly one dependency update tool configured, in the standard location for that tool
+- If Renovate: file renamed to `.github/renovate.json`, contents validated against the Renovate JSON schema
+- If Dependabot: file replaced with a valid `dependabot.yml` using the `version: 2` syntax
+- `tests/unit/redirects.test.ts` or a new unit test asserts the chosen config file exists at the correct path

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,25 +4129,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.3":
-  version: 4.1.3
-  resolution: "@vitest/expect@npm:4.1.3"
+"@vitest/expect@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@vitest/expect@npm:4.1.4"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.3"
-    "@vitest/utils": "npm:4.1.3"
+    "@vitest/spy": "npm:4.1.4"
+    "@vitest/utils": "npm:4.1.4"
     chai: "npm:^6.2.2"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/e5e27e22b8f6d7bd8e5f7a5c862a54a52c8933ae5420fab14843b0d24c8e6bd834523c30d75e5ea699717934093ac79d8fab5b6e7b451950cc6f2c0a58662598
+  checksum: 10c0/99b53a931366ddc985f26528495ec991fa2ce64018b00a56f989c322553045c5adf17e091eb7a12d786246712f84d36fc88e9d26c852538ff4dd5a6f9cf98715
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.3":
-  version: 4.1.3
-  resolution: "@vitest/mocker@npm:4.1.3"
+"@vitest/mocker@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@vitest/mocker@npm:4.1.4"
   dependencies:
-    "@vitest/spy": "npm:4.1.3"
+    "@vitest/spy": "npm:4.1.4"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
@@ -4158,56 +4158,56 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/cbe54a931756b27c454bad5a174d9c5d5d7971e06c1e2d1f97d7c267db526741adfe4825f3c7bacddb6bd0d9a9675d3220e9986ec407ae606a1d8195cf2624a2
+  checksum: 10c0/da61ee63743da4bc45df0488c994e284e7059a4005149195744705945d19aeb267c801b1f7d85e71b40f547ff2d5a195175c5d51e8455179c794ce67a019de87
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.3":
-  version: 4.1.3
-  resolution: "@vitest/pretty-format@npm:4.1.3"
+"@vitest/pretty-format@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@vitest/pretty-format@npm:4.1.4"
   dependencies:
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/07ce23b95588ae15ae0447575f8f35a65f18253a74f73ec8da01a29ff2f31f2915ced1e67fc71911521c0a317910b35967bdbcdcf97c95bb847a4bccf38d7b36
+  checksum: 10c0/14a25c5acd02b1d18f9fab01d884658edb9137008d01025273617fb000e36391e4fda1513e94a257f5e611fb09041a0c042d145a90d359c9e810c0044b12763e
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.1.3":
-  version: 4.1.3
-  resolution: "@vitest/runner@npm:4.1.3"
+"@vitest/runner@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@vitest/runner@npm:4.1.4"
   dependencies:
-    "@vitest/utils": "npm:4.1.3"
+    "@vitest/utils": "npm:4.1.4"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/41a507f138f0f14aa19869d3096e30a284270f11d39a79dd424c7f688a557bd4dd6b63d0225f9da2db47ef140b0019fec82eb87bfd6c755e817511b10ffbf3e6
+  checksum: 10c0/a942ecf2e50e4c380f0d269f87272353dc40fe354357e1ecd0c6568fd37202bb86e33db676f4ad6cc5f1ab30937bba0b278d987729b21a0f22e9827f7f577da2
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.3":
-  version: 4.1.3
-  resolution: "@vitest/snapshot@npm:4.1.3"
+"@vitest/snapshot@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@vitest/snapshot@npm:4.1.4"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.3"
-    "@vitest/utils": "npm:4.1.3"
+    "@vitest/pretty-format": "npm:4.1.4"
+    "@vitest/utils": "npm:4.1.4"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10c0/bc42c5f9e4d8fc226bd578b9679e55bc5473a96f2917db79c71015003604cbe17580d17c38361e41fbce25881ad6de0aaffe1f87a6c1e2fe37959afc44c4b754
+  checksum: 10c0/9221df7c097665a204c811184ac2f3b89638ecd115344e703e9c4361dabd2ba80be4710ed20d127817d34227a74f21b90725deaecd4632954b492ad258d4913f
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.3":
-  version: 4.1.3
-  resolution: "@vitest/spy@npm:4.1.3"
-  checksum: 10c0/aa3279c404fbb8befed0c7b797e385438b9850c2df1a462dcfccda57679dcabbdf2601fa753f46d58d72a6bee7023db65b7ab4521406489edf470367484c8b75
+"@vitest/spy@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@vitest/spy@npm:4.1.4"
+  checksum: 10c0/1036591947668845e45515d5b66b2095071609c243d2c987d650c71d0a27418e5de75a8b1ad44b7f45c5d97e71176640f0f49da94b32fb3d11e87cdd009bed26
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.1.3":
-  version: 4.1.3
-  resolution: "@vitest/utils@npm:4.1.3"
+"@vitest/utils@npm:4.1.4":
+  version: 4.1.4
+  resolution: "@vitest/utils@npm:4.1.4"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.3"
+    "@vitest/pretty-format": "npm:4.1.4"
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10c0/1cc0a0a107322a42aa6d03f578f34316da7ccfded4810400f1b2bc6e11dae8715a2b213da36878a38bb5c621b5a7a264b29b0f06d344db30f46e18f326238c70
+  checksum: 10c0/7f81db08e5a8db1e83a37a8d64db011ae3a08b5bcc9aa220a6da428385acb75b11c77b169ab7a9f753529cc25ec11406cff6099b92711fda6291f844fb840a4e
   languageName: node
   linkType: hard
 
@@ -12048,16 +12048,16 @@ __metadata:
   linkType: hard
 
 "vitest@npm:^4.0.0":
-  version: 4.1.3
-  resolution: "vitest@npm:4.1.3"
+  version: 4.1.4
+  resolution: "vitest@npm:4.1.4"
   dependencies:
-    "@vitest/expect": "npm:4.1.3"
-    "@vitest/mocker": "npm:4.1.3"
-    "@vitest/pretty-format": "npm:4.1.3"
-    "@vitest/runner": "npm:4.1.3"
-    "@vitest/snapshot": "npm:4.1.3"
-    "@vitest/spy": "npm:4.1.3"
-    "@vitest/utils": "npm:4.1.3"
+    "@vitest/expect": "npm:4.1.4"
+    "@vitest/mocker": "npm:4.1.4"
+    "@vitest/pretty-format": "npm:4.1.4"
+    "@vitest/runner": "npm:4.1.4"
+    "@vitest/snapshot": "npm:4.1.4"
+    "@vitest/spy": "npm:4.1.4"
+    "@vitest/utils": "npm:4.1.4"
     es-module-lexer: "npm:^2.0.0"
     expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
@@ -12075,12 +12075,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.3
-    "@vitest/browser-preview": 4.1.3
-    "@vitest/browser-webdriverio": 4.1.3
-    "@vitest/coverage-istanbul": 4.1.3
-    "@vitest/coverage-v8": 4.1.3
-    "@vitest/ui": 4.1.3
+    "@vitest/browser-playwright": 4.1.4
+    "@vitest/browser-preview": 4.1.4
+    "@vitest/browser-webdriverio": 4.1.4
+    "@vitest/coverage-istanbul": 4.1.4
+    "@vitest/coverage-v8": 4.1.4
+    "@vitest/ui": 4.1.4
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -12111,7 +12111,7 @@ __metadata:
       optional: false
   bin:
     vitest: vitest.mjs
-  checksum: 10c0/56f7d397ac7230df85e089402b17b2d53a621947db6d803ee6a1d168a841c7b5310e2e028aae747d8f4ba8357022124abab014e47b56aed2bcf9c241d9831369
+  checksum: 10c0/a85288778cf6a6f0222aaac547fc84f917565ba78d1e32df4693226ec93aa8675f549b246b70913e9f1d80a87830b39843f9bd96b39d270e599ff4f71def6260
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Batch-merges Renovate PRs #93 (`anthropics/claude-code-action` digest bump) and #100 (`vitest` → v4.1.4)
- Adds `git-maintenance` Makefile target (`git remote prune origin && git gc`)
- Adds `TASKS.md`
- Updates `CLAUDE.md`: document that `docker exec` is not allowed (use `docker compose run --rm app`), and that `make install` is required after any `yarn.lock` change

## Test plan
- [x] Typecheck passes
- [x] 7/7 unit tests pass (vitest v4.1.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)