### PR TITLE
fix: patch critical/high transitive dependency vulnerabilities

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,14 +3115,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@simple-git/args-pathspec@npm:^1.0.2, @simple-git/args-pathspec@npm:^1.0.3":
+"@simple-git/args-pathspec@npm:^1.0.3":
   version: 1.0.3
   resolution: "@simple-git/args-pathspec@npm:1.0.3"
   checksum: 10c0/91bfc99daa956df28e4efd683cd799f60c6d169fce6adf71a9efa80a6b5938fed4b03e55fa929cfd51aed64f3ada5c1e4edad45a3872dbd94d11924b3258b5bc
   languageName: node
   linkType: hard
 
-"@simple-git/argv-parser@npm:^1.0.3":
+"@simple-git/argv-parser@npm:^1.1.0":
   version: 1.1.1
   resolution: "@simple-git/argv-parser@npm:1.1.1"
   dependencies:
@@ -4299,11 +4299,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 
@@ -5681,9 +5681,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
   languageName: node
   linkType: hard
 
@@ -9564,9 +9564,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+  version: 1.10.0
+  resolution: "shell-quote@npm:1.10.0"
+  checksum: 10c0/46ee59bfd972ce6a45500c44ed130dff2d0a7d6fbac9841e59d548518cad8060a06393c9a5dcbc0cede294ad80b2a2cd8c904679e09265f53efc0a0879f30961
   languageName: node
   linkType: hard
 
@@ -9592,15 +9592,15 @@ __metadata:
   linkType: hard
 
 "simple-git@npm:^3.33.0":
-  version: 3.35.2
-  resolution: "simple-git@npm:3.35.2"
+  version: 3.36.0
+  resolution: "simple-git@npm:3.36.0"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
-    "@simple-git/args-pathspec": "npm:^1.0.2"
-    "@simple-git/argv-parser": "npm:^1.0.3"
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+    "@simple-git/argv-parser": "npm:^1.1.0"
     debug: "npm:^4.4.0"
-  checksum: 10c0/9cc675d4591713dc90856526f9a671ce614d2e75079988628df6eb6ce3e7ec629ae6ec77736c76960a85a9a1a6a9ee218c03eda016acb0c21bf6829f55422cb9
+  checksum: 10c0/4c22e57107535168f354e5abbbf6e618a7b39d76491ca225c70588520fbe86891f3b9a5c4f8a3fc0137e669aad2f0e11f6c6e677bfec07169cd18f29bf23cb77
   languageName: node
   linkType: hard
 
@@ -9967,8 +9967,8 @@ __metadata:
   linkType: hard
 
 "svgo@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "svgo@npm:4.0.1"
+  version: 4.0.2
+  resolution: "svgo@npm:4.0.2"
   dependencies:
     commander: "npm:^11.1.0"
     css-select: "npm:^5.1.0"
@@ -9979,7 +9979,7 @@ __metadata:
     sax: "npm:^1.5.0"
   bin:
     svgo: ./bin/svgo.js
-  checksum: 10c0/f61f9957b42e0c97593b49a01f3b93cb239b2e818efccb056fcc866d622704d9021c4ef8bd0287264c3e4f33da60e4af14d841b4a624b87ff8888e3b896d13d5
+  checksum: 10c0/d58c9446d2701dd57ef62a29b4299b157cfc32e2282f82fc68dd7cdca2e1efdf0d8bb0fb30ba0499f322d20b6304be277ffbc60a6b6a75489fa30c5300694b9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Bumps 5 transitive dependencies to their patched versions to resolve the critical and high Dependabot alerts that had a straightforward fix (single resolution in the tree, patched version already within the existing requester's semver range — no `package.json` changes needed):

| Package | Before → After | Alerts fixed | Required by |
|---|---|---|---|
| `shell-quote` | 1.8.3 → 1.10.0 | #188 (critical), #217 (high) | `launch-editor` (Vite dev-server "open in editor") |
| `brace-expansion` | 5.0.5 → 5.0.8 | #214, #227 | `minimatch` |
| `fast-uri` | 3.1.0 → 3.1.4 | #175, #176, #222, #223 | `ajv` |
| `svgo` | 4.0.1 → 4.0.2 | #216 | `postcss-svgo` |
| `simple-git` | 3.35.2 → 3.36.0 | #178 | `@nuxt/devtools` (dev-server only) |

That's 10 of the 14 open critical/high alerts.

**Deferred (not in this PR):** `postcss` (#224, #225), `vite` (#191), and `ws` (#210) each have a vulnerable resolution coexisting alongside an already-patched one elsewhere in the tree — yarn hasn't consolidated them. Fixing those requires adding `resolutions` overrides to `package.json` (same pattern already used there for `minimatch`/`nuxt-og-image`), which is a slightly bigger change deliberately left for a follow-up.

All affected packages are build/dev tooling only (Vite dev server, Nuxt devtools, asset processing) — the site is statically prerendered via `nuxt generate`, so none of this runs in the shipped production site.

## Test plan
- [x] `make typecheck` passes
- [x] `make test-unit` passes (7 tests)
- [x] `yarn build` with a cleared Nuxt cache succeeds, OG images render correctly
- [x] `yarn test:e2e` passes (3 tests)
- [ ] CI green on this PR
- [ ] Confirm alert count drops after merge via `gh api repos/technotenshi/resume/dependabot/alerts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)