### PR TITLE
ci: make typecheck non-blocking

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,6 +28,8 @@ jobs:
         cache: 'yarn'
         cache-dependency-path: yarn.lock
     - run: yarn install --immutable
-    - run: yarn typecheck
+    - name: Typecheck (non-blocking)
+      run: yarn typecheck
+      continue-on-error: true
     - run: npx playwright install --with-deps chromium
     - run: yarn test


### PR DESCRIPTION
## Summary
- `yarn typecheck` in `node.js.yml` now runs with `continue-on-error: true`. It still executes and reports on every PR, but a failure no longer fails the `build` job.
- Rationale: static site generation succeeding matters more than typecheck passing. This surfaced concretely on #154 (TypeScript v7) — `nuxt generate` (what actually ships) builds and deploys fine, but `vue-tsc@3.3.8` (the latest available) still imports an internal `typescript/lib/tsc` path that TS7's new `exports` map no longer exposes, so typecheck fails for reasons unrelated to whether the site works. That shouldn't block merges going forward.

## Test plan
- [ ] CI green on this PR (typecheck step may still show failed/warning, job should pass overall)
- [ ] Confirm `build (24.x)` job succeeds even if the typecheck step itself reports a failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)